### PR TITLE
feat(settings): ✨ Migrate to Obsidian 1.13 settings API

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -9,7 +9,7 @@
         "@types/bun": "^1.3.1",
         "@types/node": "^24.10.0",
         "esbuild": "0.27.0",
-        "obsidian": "1.10.0",
+        "obsidian": "^1.13.1",
         "tslib": "2.8.1",
         "typescript": "5.9.3",
       },
@@ -114,7 +114,7 @@
 
     "moment": ["moment@2.29.4", "", {}, "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="],
 
-    "obsidian": ["obsidian@1.10.0", "", { "dependencies": { "@types/codemirror": "5.60.8", "moment": "2.29.4" }, "peerDependencies": { "@codemirror/state": "6.5.0", "@codemirror/view": "6.38.1" } }, "sha512-F7hhnmGRQD1TanDPFT//LD3iKNUVd7N8sKL7flCCHRszfTxpDJ39j3T7LHbcGpyid906i6lD5oO+cnfLBzJMKw=="],
+    "obsidian": ["obsidian@1.13.1", "", { "dependencies": { "@types/codemirror": "5.60.8", "moment": "2.29.4" }, "peerDependencies": { "@codemirror/state": "6.5.0", "@codemirror/view": "6.38.6" } }, "sha512-qtTEA2pmhJzhuhJqzbBFRYhpIOqvW+krDYjtFynv66KbxBbumHBlsJfWw3I4jtnK/6fZwbQhCrmmDdRwXmX56w=="],
 
     "style-mod": ["style-mod@4.1.2", "", {}, "sha512-wnD1HyVqpJUI2+eKZ+eo1UwghftP6yuFheBqqe+bWCotBjC2K1YnteJILRMs3SM4V/0dLEW1SC27MWP5y+mwmw=="],
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@types/bun": "^1.3.1",
     "@types/node": "^24.10.0",
     "esbuild": "0.27.0",
-    "obsidian": "1.10.0",
+    "obsidian": "^1.13.1",
     "tslib": "2.8.1",
     "typescript": "5.9.3"
   }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,4 +1,11 @@
-import { type App, Notice, PluginSettingTab, Setting } from 'obsidian';
+import {
+  type App,
+  Notice,
+  PluginSettingTab,
+  requireApiVersion,
+  Setting,
+  type SettingDefinitionItem,
+} from 'obsidian';
 import { DefaultDateFormatter } from './dateFormatter';
 import type BirthdayTrackerPlugin from './main';
 
@@ -20,6 +27,58 @@ export class BirthdayTrackerSettingTab extends PluginSettingTab {
   constructor(app: App, plugin: BirthdayTrackerPlugin) {
     super(app, plugin);
     this.plugin = plugin;
+  }
+
+  getSettingDefinitions(): SettingDefinitionItem<
+    keyof BirthdayTrackerSettings
+  >[] {
+    if (!requireApiVersion('1.13.0')) {
+      return [];
+    }
+
+    return [
+      {
+        name: 'Date formatting',
+        desc: 'Format your dates will be displayed and collected',
+        render: (setting) => {
+          setting.addText((text) =>
+            text
+              .setPlaceholder('Enter your format')
+              .setValue(this.plugin.settings.dateFormatting)
+              .onChange(
+                async (value) =>
+                  await this.dateFormattingSettingsOnChange(value),
+              ),
+          );
+        },
+      },
+      {
+        name: 'Birthday node location',
+        desc: 'Location of your Node containing the birthday data with .md as postfix',
+        control: {
+          type: 'textarea',
+          key: 'birthdayNodeLocation',
+          placeholder: 'Enter the node location',
+        },
+      },
+      {
+        name: 'Automatically open birthday view on startup',
+        desc: 'If enabled, the birthday view is automatically opened in the right leaf when Obsidian starts',
+        control: {
+          type: 'toggle',
+          key: 'automaticallyOpenBirthdayViewOnStart',
+        },
+      },
+    ];
+  }
+
+  async setControlValue(key: string, value: unknown): Promise<void> {
+    if (!(key in this.plugin.settings)) {
+      return;
+    }
+
+    Reflect.set(this.plugin.settings, key, value);
+    await this.plugin.saveSettings();
   }
 
   display(): void {


### PR DESCRIPTION
Adds `getSettingDefinitions()` for Obsidian 1.13 while preserving the guarded legacy `display()` path, validation, auto-save, and settings refresh behavior. The Obsidian API dependency is updated for the declarative interface.

Typecheck, Biome CI checks, and production build pass.